### PR TITLE
float が 32bit 環境でバグる問題を修正

### DIFF
--- a/templates/compiler/emit.ml.tmpl
+++ b/templates/compiler/emit.ml.tmpl
@@ -159,23 +159,13 @@ and g' oc = function
 		(* IEEE756の仕様を満たす範囲内で、C言語と微妙に仕様が違うようなので結構アドホック *)
 		let hi = Int32.to_int (gethi f) in
 		let lo = Int32.to_int (getlo f) in
-		let s = lo lsr 31 in
-		let exp = (lo lsr 20) mod (1 lsl 12) in
-		let frac = lo mod (1 lsl 20) in
-		let b =
-			if exp = 0 && frac = 0 then
-				s lsl 31
-			else (
-				let exp = exp - (if s > 0 && frac <> 0 then 895 else 896) in (* 負の数だと1ずれる？ *)
-				let frac = (frac lsl 3) + (hi lsr 29) in
-				(s lsl 31) + (exp lsl 23) + frac
-			) in
-		Output.add_stmt (Output.Comment (Printf.sprintf "\t${comment} %f" f));
+		Output.add_stmt (Output.Comment (Printf.sprintf "\t${config.comment} %f" f));
 ## SETHI, SETLO, STI, LDIは絶対ある
 % if isUse("FSETHI") and isUse("FSETLO"):
-		Output.add_stmt (Output.FMvhi (x, (b lsr 16) mod (1 lsl 16)));
-		Output.add_stmt (Output.FMvlo (x, (b mod (1 lsl 16))));
+		Output.add_stmt (Output.FMvhi (x, hi));
+		Output.add_stmt (Output.FMvlo (x, lo));
 % elif isUse("ADDI"):
+(* このへんどう書き換えていいかわからないので対応おねがいします *)
 		if -32768 < b && b <= 32768 then (
 		  	Output.add_stmt (Output.Addi (reg_sw, reg_0, b));
 		  	let ss = get_stacksize () in

--- a/templates/compiler/float.c.tmpl
+++ b/templates/compiler/float.c.tmpl
@@ -3,22 +3,23 @@
 #include <caml/alloc.h>
 
 // TODO float用に書き換え
+
 typedef union
 {
-  int32 i[2];
-  double d;
-} flt;
+  int i;
+  float f;
+} fi;
 
 value gethi(value v)
 {
-  flt d;
-  d.d = (double)Double_val(v);
-  return copy_int32(d.i[0]);
+  fi f;
+  f.f = (float)Double_val(v);
+  return copy_int32(f.i >> 16);
 }
 
 value getlo(value v)
 {
-  flt d;
-  d.d = Double_val(v);
-  return copy_int32(d.i[1]);
+  fi f;
+  f.f = (float)Double_val(v);
+  return copy_int32(f.i & 0xffff);
 }


### PR DESCRIPTION
float の値を定数畳み込みして、アセンブリから fmvhi と fmvlo でレジスタにセットするときに
セットする値がことなっているためにバグっていることがわかりました。

float.c で与えられた値を明示的に float として扱うようにし、いきなり 16bit の値を返すようにすることで解決しました。

これで 32 bit マシンで動作しない問題が修正されたはずです。

fmvhi を使う系列以外は(よくわからなかったので)書き換えてないので、対応していただきたいです。
